### PR TITLE
Analytics Build 2.0 fixing:

### DIFF
--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -25,7 +25,6 @@ import com.io7m.jnull.NullCheck;
 import com.io7m.jnull.Nullable;
 
 import org.nypl.simplified.app.ProfileTimeOutActivity;
-import org.nypl.simplified.app.SimplifiedActivity;
 import org.nypl.simplified.app.R;
 import org.nypl.simplified.app.Simplified;
 import org.nypl.simplified.app.reader.ReaderPaginationChangedEvent.OpenPage;
@@ -235,9 +234,13 @@ public final class ReaderActivity extends ProfileTimeOutActivity implements
     try {
       this.profile = Simplified.getProfilesController().profileCurrent();
       this.account = this.profile.account(account_id);
-      String message = "book_opened," + this.profile.id().id() + "," + this.profile.displayName() + "," + this.getTitle();
+      String message = "book_opened," + this.profile.id().id()
+          + "," + this.profile.displayName()
+          + "," + this.account.bookDatabase().entry(book_id).book().entry().getTitle();
       Simplified.getAnalyticsController().logToAnalytics(message);  
-    } catch (final AccountsDatabaseNonexistentException | ProfileNoneCurrentException e) {
+    } catch (final AccountsDatabaseNonexistentException
+        | BookDatabaseException
+        | ProfileNoneCurrentException e) {
       this.failWithErrorMessage(this.getResources(), e);
       return;
     }
@@ -672,7 +675,9 @@ public final class ReaderActivity extends ProfileTimeOutActivity implements
     if (!pages.isEmpty()) {
       final OpenPage page = NullCheck.notNull(pages.get(0));
       String pageInfo = default_package.getSpineItem(page.getIDRef()).getTitle();
-      String message = "book_open_page," + (page.getSpineItemPageIndex() + 1) + "/" + page.getSpineItemPageCount() + "," + pageInfo;
+      String message = "book_open_page," + (page.getSpineItemPageIndex() + 1)
+          + "/" + page.getSpineItemPageCount()
+          + "," + pageInfo;
       Simplified.getAnalyticsController().logToAnalytics(message);
     }
 

--- a/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
+++ b/simplified-app-shared/src/main/java/org/nypl/simplified/app/reader/ReaderActivity.java
@@ -235,7 +235,7 @@ public final class ReaderActivity extends ProfileTimeOutActivity implements
     try {
       this.profile = Simplified.getProfilesController().profileCurrent();
       this.account = this.profile.account(account_id);
-      String message = "book_opened," + this.profile.id().id() + "," + this.profile.displayName() + "," + this.book_id;
+      String message = "book_opened," + this.profile.id().id() + "," + this.profile.displayName() + "," + this.getTitle();
       Simplified.getAnalyticsController().logToAnalytics(message);  
     } catch (final AccountsDatabaseNonexistentException | ProfileNoneCurrentException e) {
       this.failWithErrorMessage(this.getResources(), e);
@@ -671,7 +671,8 @@ public final class ReaderActivity extends ProfileTimeOutActivity implements
     final List<OpenPage> pages = e.getOpenPages();
     if (!pages.isEmpty()) {
       final OpenPage page = NullCheck.notNull(pages.get(0));
-      String message = "book_open_page," + (page.getSpineItemPageIndex() + 1) + "/" + page.getSpineItemPageCount();
+      String pageInfo = default_package.getSpineItem(page.getIDRef()).getTitle();
+      String message = "book_open_page," + (page.getSpineItemPageIndex() + 1) + "/" + page.getSpineItemPageCount() + "," + pageInfo;
       Simplified.getAnalyticsController().logToAnalytics(message);
     }
 

--- a/simplified-books-core/src/main/java/org/nypl/simplified/books/analytics/AnalyticsLogger.java
+++ b/simplified-books-core/src/main/java/org/nypl/simplified/books/analytics/AnalyticsLogger.java
@@ -47,10 +47,10 @@ public class AnalyticsLogger {
 
   private static final Logger LOG = LogUtilities.getLog(AnalyticsLogger.class);
 
-  private final String analytics_server_uri = "http://ec2-18-216-36-110.us-east-2.compute.amazonaws.com:8080/upload.log";
+  private final String analytics_server_uri = "http://ec2-18-217-127-216.us-east-2.compute.amazonaws.com:8080/upload.log";
   private final String log_file_name = "analytics_log.txt";
   private final int log_file_size_limit =  1024 * 1024 * 10;
-  private final int log_file_push_limit = 1024 * 50;
+  private final int log_file_push_limit = 1024 * 2;
   private BufferedWriter analytics_output = null;
   private File directory_analytics = null;
   private boolean log_size_limit_reached = false;


### PR DESCRIPTION
1. Do NOT use the hardcoded IP address of the server.  If the instance restarts, the IP address changes, and the app talks to the wrong IP.  Instead use an elastic IP.
2. Scrape all logs in their current form from the devices (this will be a data dump we receive to get all of the logs that are out there collecting now that never hit 50kb).
3. Start new logs and make their send limit 2kb or thereabouts.
4. Change the book identifier from "BookId" to "actual book title"
5. Fix page numbers so they are not 1/1 half the time.

@io7m @winniequinn 